### PR TITLE
Create missing directories.

### DIFF
--- a/neverpile-eureka-bridge-storage-filesystem/src/main/java/com/neverpile/eureka/bridge/storage/fs/FilesystemObjectStoreService.java
+++ b/neverpile-eureka-bridge-storage-filesystem/src/main/java/com/neverpile/eureka/bridge/storage/fs/FilesystemObjectStoreService.java
@@ -376,6 +376,9 @@ public class FilesystemObjectStoreService implements ObjectStoreService {
     try {
       // return the object of the given name...
       Path start = toPathWithRoot(prefix);
+      if(!Files.exists(start)) {
+        Files.createDirectories(start);
+      }
       return Files.walk(start, 1) //
           .filter(p -> !p.equals(start)) // exclude start directory
           .map(p -> p.toFile().isDirectory() ? toPrefix(p) : toStoreObject(p));


### PR DESCRIPTION
Filesystem object-store throws IO-Exception when the document/policy folder doesn't exist.
Now the folder will ber cerated instead.