### PR TITLE
Feature/#3 exclude o auth from neverpile eureka spring boot starter

### DIFF
--- a/neverpile-eureka-bom/neverpile-eureka-spring-boot-bom/neverpile-eureka-spring-boot-starter/pom.xml
+++ b/neverpile-eureka-bom/neverpile-eureka-spring-boot-bom/neverpile-eureka-spring-boot-starter/pom.xml
@@ -24,10 +24,6 @@
     </dependency>
     <dependency>
       <groupId>com.neverpile.eureka</groupId>
-      <artifactId>neverpile-eureka-security-oauth2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.neverpile.eureka</groupId>
       <artifactId>neverpile-eureka-authorization</artifactId>
     </dependency>
     <dependency>

--- a/neverpile-eureka-core/src/main/java/com/neverpile/eureka/autoconfig/NeverpileEurekaAutoConfiguration.java
+++ b/neverpile-eureka-core/src/main/java/com/neverpile/eureka/autoconfig/NeverpileEurekaAutoConfiguration.java
@@ -3,6 +3,7 @@ package com.neverpile.eureka.autoconfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
 import org.springframework.web.context.annotation.RequestScope;
 
 import com.neverpile.authorization.api.AuthorizationService;
@@ -57,6 +59,7 @@ import com.neverpile.eureka.tx.wal.local.FileBasedWAL;
      */
     JacksonConfiguration.class, EventPublisher.class, UpdateEventAggregator.class
 })
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class NeverpileEurekaAutoConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(NeverpileEurekaAutoConfiguration.class);
 

--- a/neverpile-eureka-core/src/main/java/com/neverpile/eureka/autoconfig/NeverpileEurekaAutoConfiguration.java
+++ b/neverpile-eureka-core/src/main/java/com/neverpile/eureka/autoconfig/NeverpileEurekaAutoConfiguration.java
@@ -11,7 +11,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.Ordered;
 import org.springframework.web.context.annotation.RequestScope;
 
 import com.neverpile.authorization.api.AuthorizationService;
@@ -59,7 +58,7 @@ import com.neverpile.eureka.tx.wal.local.FileBasedWAL;
      */
     JacksonConfiguration.class, EventPublisher.class, UpdateEventAggregator.class
 })
-@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+@AutoConfigureOrder(AutoConfigureOrder.DEFAULT_ORDER + 1)
 public class NeverpileEurekaAutoConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(NeverpileEurekaAutoConfiguration.class);
 

--- a/neverpile-eureka-core/src/main/java/com/neverpile/eureka/rest/configuration/SpringHateoasIssue705WorkAround.java
+++ b/neverpile-eureka-core/src/main/java/com/neverpile/eureka/rest/configuration/SpringHateoasIssue705WorkAround.java
@@ -35,7 +35,9 @@ public class SpringHateoasIssue705WorkAround implements BeanPostProcessor {
     }
 
     ObjectMapper mapper = (ObjectMapper) bean;
-    mapper.registerModule(m1);
+    if(m1 != null) {
+      mapper.registerModule(m1);
+    }
     mapper.setAnnotationIntrospector(new AnnotationIntrospectorPair(new JacksonAnnotationIntrospector(),
         new JaxbAnnotationIntrospector(TypeFactory.defaultInstance())));
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/neverpile-eureka-core/src/main/java/com/neverpile/eureka/rest/configuration/SpringHateoasIssue705WorkAround.java
+++ b/neverpile-eureka-core/src/main/java/com/neverpile/eureka/rest/configuration/SpringHateoasIssue705WorkAround.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
  */
 @Component
 public class SpringHateoasIssue705WorkAround implements BeanPostProcessor {
-  @Autowired
+  @Autowired(required = false)
   FacetedDocumentDtoModule m1;
   
   /*

--- a/neverpile-eureka-hazelcast/src/main/java/com/neverpile/eureka/hazelcast/NeverpileHazelcastAutoConfiguration.java
+++ b/neverpile-eureka-hazelcast/src/main/java/com/neverpile/eureka/hazelcast/NeverpileHazelcastAutoConfiguration.java
@@ -2,7 +2,6 @@ package com.neverpile.eureka.hazelcast;
 
 import org.springframework.beans.factory.InjectionPoint;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -12,7 +11,6 @@ import org.springframework.context.annotation.Scope;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
-import com.neverpile.eureka.autoconfig.NeverpileEurekaAutoConfiguration;
 import com.neverpile.eureka.hazelcast.queue.HazelcastTaskQueue;
 import com.neverpile.eureka.hazelcast.wal.HazelcastWAL;
 import com.neverpile.eureka.tasks.DistributedPersistentQueueType;
@@ -22,7 +20,6 @@ import com.neverpile.eureka.tx.wal.WriteAheadLog;
 @Configuration
 @ConditionalOnProperty(name = "neverpile-eureka.hazelcast.enabled", havingValue = "true", matchIfMissing = false)
 @ComponentScan
-@AutoConfigureBefore(NeverpileEurekaAutoConfiguration.class)
 public class NeverpileHazelcastAutoConfiguration {
   @Autowired
   HazelcastConfigurationProperties hazelcastConfig;


### PR DESCRIPTION
OAuth2 security is now excluded from neverpile-eureka-spring-boot-starter.
+ auto-configuration order fixed.
+ Fixed some wired behavior with the Hateoas 705 workaround.