### PR TITLE
Fix / NE-3: streamline cassandra config

### DIFF
--- a/neverpile-eureka-core/src/main/java/com/neverpile/eureka/api/ContentElementService.java
+++ b/neverpile-eureka-core/src/main/java/com/neverpile/eureka/api/ContentElementService.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
-import com.neverpile.eureka.api.ObjectStoreService.StoreObject;
 import com.neverpile.eureka.model.ContentElement;
 import com.neverpile.eureka.model.Document;
 import com.neverpile.eureka.model.ObjectName;

--- a/neverpile-eureka-objectstore-cassandra/src/main/java/com/neverpile/eureka/objectstore/cassandra/AbstractNeverpileCassandraConfig.java
+++ b/neverpile-eureka-objectstore-cassandra/src/main/java/com/neverpile/eureka/objectstore/cassandra/AbstractNeverpileCassandraConfig.java
@@ -2,13 +2,13 @@ package com.neverpile.eureka.objectstore.cassandra;
 
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.cassandra.config.AbstractCassandraConfiguration;
 import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
 
-import com.neverpile.eureka.api.ObjectStoreService;
-
+@EnableCassandraRepositories(basePackages = "com.neverpile.eureka.objectstore.cassandra")
+@Import(CassandraTransactionConfiguration.class)
 public abstract class AbstractNeverpileCassandraConfig extends AbstractCassandraConfiguration {
 
   public enum ReplicationStrategy {
@@ -45,18 +45,7 @@ public abstract class AbstractNeverpileCassandraConfig extends AbstractCassandra
     return SchemaAction.CREATE_IF_NOT_EXISTS;
   }
 
-  @Bean
-  @Primary
-  public ObjectStoreService cassandraObjectStoreService() {
-    return new CassandraObjectStoreService();
-  }
-//
-//  @Bean
-//  public CassandraMappingContext cassandraMapping() {
-//    return new BasicCassandraMappingContext();
-//  }
-
-  @Value("${neverpile-eureka.cassandra.keyspace-name:objectKeySpace}")
+  @Value("${neverpile-eureka.storage.cassandra.keyspace-name:objectKeySpace}")
   protected void setKeyspaceName(final String keyspaceName) {
     this.keyspaceName = keyspaceName;
   }
@@ -65,7 +54,7 @@ public abstract class AbstractNeverpileCassandraConfig extends AbstractCassandra
     return replicationFactor;
   }
 
-  @Value("${neverpile-eureka.cassandra.replication-factor:1}")
+  @Value("${neverpile-eureka.storage.cassandra.replication-factor:1}")
   void setReplicationFactor(final int replicationFactor) {
     this.replicationFactor = replicationFactor;
   }
@@ -74,9 +63,8 @@ public abstract class AbstractNeverpileCassandraConfig extends AbstractCassandra
     return replicationStrategy;
   }
 
-  @Value("${neverpile-eureka.cassandra.replication-strategy:Simple}")
+  @Value("${neverpile-eureka.storage.cassandra.replication-strategy:Simple}")
   void setReplicationStrategy(final ReplicationStrategy replicationStrategy) {
     this.replicationStrategy = replicationStrategy;
   }
-
 }

--- a/neverpile-eureka-objectstore-cassandra/src/main/java/com/neverpile/eureka/objectstore/cassandra/CassandraHealthIndicator.java
+++ b/neverpile-eureka-objectstore-cassandra/src/main/java/com/neverpile/eureka/objectstore/cassandra/CassandraHealthIndicator.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.cassandra.SessionFactory;
 import org.springframework.data.cassandra.core.CassandraOperations;
@@ -18,7 +19,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 
 @Component("CassandraHealthIndicator")
-@ConditionalOnExpression("${neverpile-eureka.cassandra.enabled}")
+@ConditionalOnProperty(prefix = "neverpile-eureka.storage.cassandra", value = "enabled")
 public class CassandraHealthIndicator implements HealthIndicator {
 
   @Autowired(required = false)

--- a/neverpile-eureka-objectstore-s3/src/main/java/com/neverpile/eureka/objectstore/s3/S3ConnectionConfiguration.java
+++ b/neverpile-eureka-objectstore-s3/src/main/java/com/neverpile/eureka/objectstore/s3/S3ConnectionConfiguration.java
@@ -11,9 +11,9 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.Region;
 
 /**
  * Configuration properties for an S3 connection.
@@ -33,12 +33,12 @@ public class S3ConnectionConfiguration implements Serializable {
      * syntax, however, requires that you use the region-specific endpoint when attempting to access
      * a bucket.
      */
-    Path, 
-    
+    Path,
+
     /**
      * The default behaviour is to detect which access style to use based on the configured
      * endpoint (an IP will result in path-style access) and the bucket being accessed (some buckets
-     * are not valid DNS names). 
+     * are not valid DNS names).
      */
     Automatic
   }
@@ -60,15 +60,17 @@ public class S3ConnectionConfiguration implements Serializable {
   private ClientConfiguration clientConfiguration = new ClientConfiguration();
 
   private boolean disableCertificateChecking;
-  
+
   public AmazonS3 createClient() {
     AWSCredentials credentials = new BasicAWSCredentials(getAccessKeyId(), getSecretAccessKey());
 
-    System.setProperty(SDKGlobalConfiguration.DISABLE_CERT_CHECKING_SYSTEM_PROPERTY, Boolean.toString(disableCertificateChecking));
-    
+    System.setProperty(SDKGlobalConfiguration.DISABLE_CERT_CHECKING_SYSTEM_PROPERTY,
+        Boolean.toString(disableCertificateChecking));
+
     return AmazonS3ClientBuilder.standard() //
         .withCredentials(new AWSStaticCredentialsProvider(credentials)) //
-        .withEndpointConfiguration(new EndpointConfiguration(this.getEndpoint(), Regions.US_EAST_1.name())) //
+        .withEndpointConfiguration(
+            new EndpointConfiguration(this.getEndpoint(), Region.EU_Frankfurt.getFirstRegionId())) //
         .withClientConfiguration(getClientConfiguration()) //
         .withPathStyleAccessEnabled(accessStyle == AccessStyle.Path) //
         .build();

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <dependency-check-maven.version>8.0.2</dependency-check-maven.version>
 
-    <neverpile-commons.version>1.6.4</neverpile-commons.version>
+    <neverpile-commons.version>1.6.5</neverpile-commons.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
fix(NE-3): make cassandra config easier to use and modify and streamline properties path to match FS and S3

Ich hab FS und Cassandra als PoC für die Integration eines MultiStorage Services verwendet und dabei sind mir ein paar kleinere ungreimtheiten aufgefallen, die jetzt in diesem PR zurück ins Produkt fließen sollen.