### PR TITLE
Bugfix/jf 732 ehcache conflicting

### DIFF
--- a/neverpile-eureka-bom/neverpile-eureka-spring-boot-bom/pom.xml
+++ b/neverpile-eureka-bom/neverpile-eureka-spring-boot-bom/pom.xml
@@ -16,8 +16,8 @@
   </modules>
 
   <properties>
-    <dropwizard.version>4.2.20</dropwizard.version>
-    <elasticsearch.version>7.17.13</elasticsearch.version>
+    <dropwizard.version>4.2.21</dropwizard.version>
+    <elasticsearch.version>7.17.14</elasticsearch.version>
   </properties>
 
   <dependencyManagement>

--- a/neverpile-eureka-objectstore-ehcache/src/main/java/com/neverpile/eureka/objectstore/ehcache/EhcacheConfig.java
+++ b/neverpile-eureka-objectstore-ehcache/src/main/java/com/neverpile/eureka/objectstore/ehcache/EhcacheConfig.java
@@ -3,7 +3,7 @@ package com.neverpile.eureka.objectstore.ehcache;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -12,7 +12,7 @@ import com.neverpile.eureka.api.ObjectStoreService;
 import com.neverpile.eureka.autoconfig.NeverpileEurekaAutoConfiguration;
 
 @Configuration
-@ConditionalOnMissingBean(ObjectStoreService.class)
+@ConditionalOnProperty(name = "neverpile-eureka.storage.ehcache.enabled", havingValue = "true", matchIfMissing = false)
 @AutoConfigureBefore(
     value = NeverpileEurekaAutoConfiguration.class)
 // we want to provide our goods before NeverpileEurekaAutoConfiguration etc

--- a/pom.xml
+++ b/pom.xml
@@ -15,53 +15,49 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <spring-boot.version>2.7.16</spring-boot.version>
+    <spring-boot.version>2.7.17</spring-boot.version>
     <spring-security-oauth2.version>2.6.8</spring-security-oauth2.version>
+    <spring-boot-admin.version>${spring-boot.version}</spring-boot-admin.version>
 
-    <spring-boot-admin.version>2.7.16</spring-boot-admin.version>
     <springfox.version>3.0.0</springfox.version>
-    <swagger.version>2.2.16</swagger.version>
+    <swagger.version>2.2.17</swagger.version>
 
-    <feign.version>8.18.0</feign.version>
-    <jetty.version>9.4.52.v20230823</jetty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
 
-    <jmockit.version>1.49</jmockit.version>
-
-    <elasticsearch.version>7.17.13</elasticsearch.version>
+    <elasticsearch.version>7.17.14</elasticsearch.version>
+    <lucene.version>8.11.1</lucene.version>
 
     <ignite.version>2.14.0</ignite.version>
     <ignite-cloud.version>2.13.0</ignite-cloud.version>
     <ignite-aws.version>2.11.1</ignite-aws.version>
+    <guava.version>32.1.3-jre</guava.version>
 
-    <lucene.version>8.11.1</lucene.version>
-
-    <guava.version>32.1.2-jre</guava.version>
-
+    <aws-s3.version>1.12.564</aws-s3.version>
     <cassandra-driver-core.version>4.17.0</cassandra-driver-core.version>
+    <ehcache.version>3.10.8</ehcache.version>
+    <h2.version>2.1.214</h2.version>
 
     <url-crypto-kit.version>1.4.1</url-crypto-kit.version>
     <eureka-webjar.version>1.0.25</eureka-webjar.version>
+    <neverpile-commons.version>1.8.1</neverpile-commons.version>
 
     <opentracing.version>0.33.0</opentracing.version>
-
-    <mockito-core.version>4.11.0</mockito-core.version>
-    <metrics-core.version>4.2.20</metrics-core.version>
+    <metrics-core.version>4.2.21</metrics-core.version>
     <modelmapper.version>1.1.3</modelmapper.version>
 
-    <aws-s3.version>1.12.564</aws-s3.version>
+    <!-- test -->
+    <mockito-core.version>4.11.0</mockito-core.version>
+    <rest-assured.version>4.5.1</rest-assured.version>
     <s3mock.version>2.17.0</s3mock.version>
-    <ehcache.version>3.10.8</ehcache.version>
 
     <!-- plugins -->
     <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
-    <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
-    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.2.1</maven-failsafe-plugin.version>
+    <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <dependency-check-maven.version>8.4.0</dependency-check-maven.version>
-
-    <neverpile-commons.version>1.8.1</neverpile-commons.version>
+    <dependency-check-maven.version>8.4.2</dependency-check-maven.version>
   </properties>
 
   <repositories>
@@ -129,24 +125,9 @@
         <version>${swagger.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.netflix.feign</groupId>
-        <artifactId>feign-core</artifactId>
-        <version>${feign.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.netflix.feign</groupId>
-        <artifactId>feign-jackson</artifactId>
-        <version>${feign.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
         <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jmockit</groupId>
-        <artifactId>jmockit</artifactId>
-        <version>${jmockit.version}</version>
       </dependency>
 
       <!-- elasticsearch -->
@@ -170,7 +151,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.1.214</version>
+        <version>${h2.version}</version>
       </dependency>
 
       <!-- other stuff -->
@@ -308,7 +289,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.5.1</version>
+        <version>${rest-assured.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
Wenn Ehcache per default enabled ist, gibt es Konflikte wenn man einen anderen ObjectStore enabled (s.u.). Man hätte evtl auch die `@AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE`) ändern können

```
Field objectStore in com.neverpile.eureka.impl.documentservice.DefaultMultiVersioningDocumentService required a single bean, but 2 were found:
	- ehcacheObjectStoreService: defined by method 'ehcacheObjectStoreService' in class path resource [com/neverpile/eureka/objectstore/ehcache/EhcacheConfig.class]
	- s3ObjectStoreService: defined by method 's3ObjectStoreService' in class path resource [com/neverpile/eureka/objectstore/s3/S3ObjectStoreAutoConfiguration.class]
```